### PR TITLE
(fix): Resolve nullable parameter deprecation warnings for v1

### DIFF
--- a/src/Models/ShoppingCart.php
+++ b/src/Models/ShoppingCart.php
@@ -69,7 +69,7 @@ class ShoppingCart extends Model
         );
     }
 
-    public function addCustom(string $description, Price $price, string $type, bool $visible_in_cart = true, float $quantity = 1, Product $product = null, bool $should_combine_products = true): ShoppingCartItem
+    public function addCustom(string $description, Price $price, string $type, bool $visible_in_cart = true, float $quantity = 1, ?Product $product = null, bool $should_combine_products = true): ShoppingCartItem
     {
         $cart = ($this->id) ? $this : config('cart.models.shopping_cart')::completelyNew();
 

--- a/src/Traits/PriceFormatter.php
+++ b/src/Traits/PriceFormatter.php
@@ -6,7 +6,7 @@ use Marshmallow\Priceable\Facades\Price;
 
 trait PriceFormatter
 {
-    public function getFormatted(string $method_column_or_value = null): string
+    public function getFormatted(?string $method_column_or_value = null): string
     {
         $method_column_or_value = $method_column_or_value ?? 0;
 


### PR DESCRIPTION
Fixes #239 for v1 branch

This PR resolves 62 deprecation warnings by explicitly marking parameters as nullable using the ? syntax:

- **ShoppingCart::addCustom()** - Changed `Product $product = null` to `?Product $product = null`
- **PriceFormatter::getFormatted()** - Changed `string $method_column_or_value = null` to `?string $method_column_or_value = null`

This addresses the PHP deprecation warnings about implicitly marking parameters as nullable.

## Changes
- [x] Updated ShoppingCart.php line 72
- [x] Updated PriceFormatter.php line 9

## Testing
No functional changes, only type annotations. Existing tests should continue to pass.