### PR TITLE
chore(deps): allow marshmallow/payable ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "marshmallow/nova-flexible": "^v5.2.1",
         "marshmallow/priceable": "^v3.0.0",
         "marshmallow/products": "^v5.0.0",
-        "marshmallow/payable": "^v2.0.0 || ^3.0.0",
+        "marshmallow/payable": "^v2.0.0 || ^3.0.0 || ^4.0",
         "marshmallow/dataset-country": "^v1.2.2",
         "marshmallow/addressable": "^v1.6.1",
         "laravel/nova": "^5.0"


### PR DESCRIPTION
Widens the `marshmallow/payable` constraint to allow v4.

## Why now

`marshmallow/payable` v4.0.0 is tagged. vdhpower pulls payable transitively
through this package, so this line is the only thing keeping it on v2:

```
Problem 1
  - Root composer.json requires marshmallow/payable ^4.0, found
    marshmallow/payable[v4.0.0] but these were not loaded, likely because it
    conflicts with another require.
Problem 2
  - marshmallow/cart 5.0.0 requires marshmallow/payable ^v2.0.0 -> found
    marshmallow/payable[v2.0.0, ..., v2.11.2] but it conflicts with your root
    composer.json require (^4.0).
```

Note `main` already allows `^3.0.0`, but the released 5.0.0 still carries
`^v2.0.0` — so a release is needed for this to reach anyone.

## Why it's safe

Cart touches exactly two symbols from payable:

```
Marshmallow\Payable\Traits\Payable
Marshmallow\Payable\Traits\PayableWithItems
```

Both are **byte-identical between v2.11.2 and v4.0.0** (`git diff v2.11.2
v4.0.0 -- src/Traits/Payable.php` is empty, same for the other). `startPayment()`'s
signature is unchanged.

Nothing v4 removed or changed is reachable from this package: no Nova resources,
no Adyen / PayPal / Ippies providers, no Mollie Orders API, no
`use_order_payments`.

## What this unblocks

With this released, vdhpower can move to a real `^4.0` instead of the
`dev-main as 2.99.99` alias it is on for testing.
