### PR TITLE
chore(deps): allow marshmallow/payable ^4.0 on the v2 line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "marshmallow/nova-field-string-generator": "^v2.0.0",
         "marshmallow/priceable": "^v3.0.0",
         "marshmallow/products": "^v3.0.0",
-        "marshmallow/payable": "^v2.0.0",
+        "marshmallow/payable": "^v2.0.0 || ^4.0",
         "marshmallow/dataset-country": "^v1.2.2",
         "marshmallow/addressable": "^v1.6.1",
         "marshmallow/nova-tabs": "^2.0.3",


### PR DESCRIPTION
Same change as #306, on the `v2` line.

```diff
-        "marshmallow/payable": "^v2.0.0",
+        "marshmallow/payable": "^v2.0.0 || ^4.0",
```

## Why it's safe

`v2` uses exactly two symbols from payable:

```
Marshmallow\Payable\Traits\Payable
Marshmallow\Payable\Traits\PayableWithItems
```

Both are **byte-identical between v2.11.2 and v4.0.0** — `git diff v2.11.2
v4.0.0 -- src/Traits/Payable.php` is empty, same for the other. `startPayment()`'s
signature is unchanged.

Nothing v4 removed or changed is reachable from this branch: no Nova resources,
no Adyen / PayPal / Ippies, no Mollie Orders API, no `use_order_payments`.

## It's an option, not an upgrade

`v2` supports PHP `^8.0`; payable v4 needs `^8.2`. So composer keeps resolving
payable 2.x on older platforms and can pick v4 only where the platform already
allows it. Nothing is forced onto anyone.

## One thing to decide

This leaves the constraint as `^v2.0.0 || ^4.0` — v3 is skipped. That mirrors
what was asked for, but the gap is arbitrary: the same traits are identical on
v3 too, so there is no technical reason to exclude it. `main` allows
`^v2.0.0 || ^3.0.0 || ^4.0`. Say the word and I'll match it here.
