### PR TITLE
fix(order): find existing order without global scopes on conversion

### DIFF
--- a/src/Models/Order.php
+++ b/src/Models/Order.php
@@ -29,9 +29,15 @@ class Order extends Model
     public static function createUniqueFromShoppingCart(ShoppingCart $shoppingCart)
     {
         /**
-         * Check if its already converted.
+         * Check if its already converted. Without global scopes on purpose:
+         * an application can hide not-yet-finalized orders behind a global
+         * scope, and missing an existing order here would violate the unique
+         * shopping_cart_id constraint.
          */
-        $order = self::where('shopping_cart_id', $shoppingCart->id)->first();
+        $order = self::query()
+            ->withoutGlobalScopes()
+            ->where('shopping_cart_id', $shoppingCart->id)
+            ->first();
         if ($order) {
             if ($order->customer_id && !$shoppingCart->customer_id) {
                 $shoppingCart->update([
@@ -99,10 +105,12 @@ class Order extends Model
              * Delete the address of the prospect. We will be deleting
              * the prospect as well because it's not a prospect anymore.
              */
-            $prospect->addresses->each(function ($address) {
-                $address->delete();
-            });
-            $prospect->delete();
+            if ($prospect) {
+                $prospect->addresses->each(function ($address) {
+                    $address->delete();
+                });
+                $prospect->delete();
+            }
         }
 
 


### PR DESCRIPTION
## What

- `Order::createUniqueFromShoppingCart()` looks up the existing order for a cart without global scopes.
- The prospect cleanup is guarded with `if ($prospect)` (it can be null when the prospect row was hard-deleted).

## Why

Applications can hide not-yet-finalized orders behind a global scope (VDH Power creates concept orders before the payment starts, MM-24695). With a scoped lookup the existing order is missed and the subsequent create violates the unique `shopping_cart_id` constraint on the paid conversion.

## Note for consumers

The vendor `OrderCreated` event now fires at the moment the (concept) order row is created when an application converts before payment — no behavior change for apps that convert on payment like before.